### PR TITLE
Add customizable stage naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StageInvaders
 
-Demcon stage planner challenge
+Demcon stage planner challenge.
 
 ## Usage
 
@@ -30,3 +30,34 @@ STAGE_NAMES = ["Main Stage", "Side Stage"]
 ```
 
 When a stage number exceeds the available names, the script prints `Stage <n>` for that entry.
+
+## Schedule generator
+
+`schedule_generator.py` assigns shows to stages so that no overlapping shows
+share a stage and the number of stages is minimised.
+
+```bash
+python schedule_generator.py --input input_shows.py --output schedule.json
+```
+
+The `--input` argument accepts a Python or JSON file containing a `shows` list.
+If `--output` is supplied the resulting schedule is written as JSON.
+
+## Random show generator
+
+`random_shows.py` provides a `generate_random_shows` helper to create random
+show lists from a fixed set of band names:
+
+```python
+from random_shows import generate_random_shows
+
+shows = generate_random_shows(10)
+```
+
+## Testing
+
+Run the unit tests with:
+
+```bash
+pytest
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # StageInvaders
+
 Demcon stage planner challenge
+
+## Usage
+
+Generate the sample schedule with default, punny stage names:
+
+```bash
+python schedule_generator.py
+```
+
+Provide your own stage names from a JSON or Python file:
+
+```bash
+python schedule_generator.py --stage-names names.json
+python schedule_generator.py --stage-names names.py
+```
+
+`names.json` should contain an array of strings:
+
+```json
+["Main Stage", "Side Stage"]
+```
+
+`names.py` should define a list named `STAGE_NAMES`:
+
+```python
+STAGE_NAMES = ["Main Stage", "Side Stage"]
+```
+
+When a stage number exceeds the available names, the script prints `Stage <n>` for that entry.

--- a/input_shows.py
+++ b/input_shows.py
@@ -1,0 +1,7 @@
+"""Sample list of shows for the schedule generator."""
+
+shows = [
+    ("show_1", 36, 39),
+    ("show_2", 30, 33),
+    ("show_3", 29, 36),
+]

--- a/random_shows.py
+++ b/random_shows.py
@@ -1,0 +1,106 @@
+"""Utility for generating random festival shows."""
+
+from __future__ import annotations
+
+import random
+from typing import List, Sequence, Tuple
+
+Show = Tuple[str, float, float]
+
+band_names: Sequence[str] = [
+    "The Demi-Conductors",
+    "Molten Salt 'n Pepper",
+    "Electrolyzer Boys II H₂",
+    "CryoJazz Quartet: Kelvin & the Degrees",
+    "Qubit & The Entanglers",
+    "Biopsy Bot Bi-Metal",
+    "Servo Skynet Funk",
+    "SMR Metalcore Reactor",
+    "Thorizon Thunderlords",
+    "Hydrogenated Groove Machine",
+    "OptoMech Overload",
+    "MechaTronic BoomBap",
+    "Cleanroom Crooners",
+    "DICE Rollers",
+    "Plasma Etch Ninjas",
+    "Stack Pressure Funk Collective",
+    "Vapor Deposition Devotees",
+    "Superfluid Funkadelic",
+    "Rotor & The Cryostats",
+    "Kelvinators of Love",
+    "Overlapocalypse Now",
+    "Flux Capacitor Leakage",
+    "Servo Servo Go!",
+    "Chip Placement Misfits",
+    "Magnetic Resonance Rockers",
+    "Needle Drive & The Scanner Bots",
+    "Hydride & Seek",
+    "Robolap Partners",
+    "QCryo & The Coolants",
+    "MiniModular Menace",
+    "Bionic Stagecraft",
+    "The DemCon-Artists",
+    "DeMCONic Force Five",
+    "DemConfidential Rappers",
+    "GrindCore XY Stage",
+    "Pulse Tube Troubadours",
+    "Leak Test Lounge Lizards",
+    "Servo Sirens",
+    "True Grit & Grippers",
+    "Ampere Time Machine",
+    "Proton Pump Funk Unit",
+    "SaltCore Grinder",
+    "ThoriZoners",
+    "Quantum Flippin’ Bits",
+    "Femtosecond Headbang",
+    "AlgorithmiX & the Min-Heaps",
+    "Hydrogen Rage Machine",
+    "Cryogenics & Roses",
+    "Cobot Cabal Choir",
+    "Valve Body Voodoo",
+    "OptoElectro Swingers",
+    "SMRizing Demolition",
+    "Servo Serpe nts",
+    "Luer & Order",
+    "Coolant Flow Ragga",
+]
+
+
+def generate_random_shows(
+    count: int,
+    *,
+    start_hour: float = 0.0,
+    end_hour: float = 24.0,
+    min_duration: float = 0.5,
+    max_duration: float = 3.0,
+    rng: random.Random | None = None,
+) -> List[Show]:
+    """Generate a list of random shows using the :data:`band_names` list.
+
+    Args:
+        count: Number of shows to generate.
+        start_hour: Earliest possible start time.
+        end_hour: Latest possible end time.
+        min_duration: Minimum length of a show in hours.
+        max_duration: Maximum length of a show in hours.
+        rng: Optional ``random.Random`` instance for reproducibility.
+
+    Returns:
+        A list of ``(name, start, end)`` tuples.
+    """
+    if rng is None:
+        rng = random
+
+    if count <= len(band_names):
+        names = list(rng.sample(band_names, count))
+    else:
+        names = list(rng.sample(band_names, len(band_names)))
+        names += list(rng.choices(band_names, k=count - len(band_names)))
+
+    shows: List[Show] = []
+    for name in names:
+        start = rng.uniform(start_hour, end_hour - min_duration)
+        duration = rng.uniform(min_duration, min(max_duration, end_hour - start))
+        end = start + duration
+        shows.append((name, round(start, 2), round(end, 2)))
+    return shows

--- a/schedule_generator.py
+++ b/schedule_generator.py
@@ -1,0 +1,128 @@
+import argparse
+import json
+import random
+import runpy
+from typing import Iterable, List
+
+stage_prefixes = [
+    "Heisenberg",
+    "Optical",
+    "Qubit",
+    "Cryo",
+    "Flux",
+    "Kelvin",
+    "Servo",
+    "Photon",
+    "Plasma",
+    "Gripper",
+    "Ampere",
+    "Hydrogen",
+    "Quantum",
+    "DICE",
+    "Nano",
+    "Circuit",
+    "Magnetron",
+    "Molten",
+    "PhaseShift",
+    "Thorizon",
+]
+
+stage_suffixes = [
+    "Dome",
+    "Colosseum",
+    "Planetarium",
+    "Lab",
+    "Core",
+    "Reactor",
+    "Arena",
+    "Theatre",
+    "Chamber",
+    "Nest",
+    "Generator",
+    "Loop",
+    "Vortex",
+    "Box",
+    "Sanctum",
+    "Station",
+    "Pit",
+    "Quadrant",
+    "Yard",
+    "Cage",
+]
+
+# Epic Main Stage suggestions
+main_stages = [
+    "The Quantum Nexus",
+    "The Mechatronic Arena",
+    "The Reactor of Legends",
+    "The Core Stage",
+    "The Dome of Infinity",
+]
+
+
+def _generate_default_stage_names(count: int = 5) -> List[str]:
+    """Generate a list of default stage names."""
+    names = [random.choice(main_stages)]
+    for _ in range(count - 1):
+        names.append(f"{random.choice(stage_prefixes)} {random.choice(stage_suffixes)}")
+    return names
+
+
+STAGE_NAMES = _generate_default_stage_names()
+
+
+def load_stage_names(path: str) -> List[str]:
+    """Load stage names from a JSON or Python file."""
+    if path.endswith(".json"):
+        with open(path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        if not isinstance(data, list) or not all(isinstance(s, str) for s in data):
+            raise ValueError("JSON stage names must be a list of strings")
+        return data
+    if path.endswith(".py"):
+        data = runpy.run_path(path)
+        names = data.get("STAGE_NAMES") or data.get("stage_names")
+        if names is None:
+            raise ValueError("Python file must define STAGE_NAMES or stage_names")
+        if not isinstance(names, list) or not all(isinstance(s, str) for s in names):
+            raise ValueError("STAGE_NAMES must be a list of strings")
+        return names
+    raise ValueError("Unsupported file type for stage names; use .json or .py")
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="Generate and print a schedule.")
+    parser.add_argument(
+        "--stage-names",
+        help="Path to JSON or Python file providing custom STAGE_NAMES",
+    )
+    return parser.parse_args(argv)
+
+
+def print_schedule(schedule: Iterable[dict], stage_names: List[str] | None = None):
+    if stage_names is None:
+        stage_names = STAGE_NAMES
+    for slot in schedule:
+        stage_num = slot["stage"]
+        if 0 < stage_num <= len(stage_names):
+            name = stage_names[stage_num - 1]
+        else:
+            name = f"Stage {stage_num}"
+        print(f"{slot['time']} - {name} - {slot['band']}")
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    stage_names = STAGE_NAMES
+    if args.stage_names:
+        stage_names = load_stage_names(args.stage_names)
+    example_schedule = [
+        {"time": "10:00", "stage": 1, "band": "Opening Act"},
+        {"time": "11:00", "stage": 2, "band": "Midday Jam"},
+        {"time": "12:00", "stage": 6, "band": "Closing Band"},
+    ]
+    print_schedule(example_schedule, stage_names)
+
+
+if __name__ == "__main__":
+    main()

--- a/schedule_generator.py
+++ b/schedule_generator.py
@@ -1,8 +1,22 @@
+"""Stage schedule generator for music festivals.
+
+This script assigns shows to stages so that no overlapping shows share a stage
+while minimising the total number of stages required. It can be run as a
+stand-alone script or imported as a module.
+"""
+
+from __future__ import annotations
+
 import argparse
+import importlib.util
 import json
 import random
 import runpy
-from typing import Iterable, List
+from heapq import heappop, heappush
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+# Default stage name generation -------------------------------------------------
 
 stage_prefixes = [
     "Heisenberg",
@@ -90,39 +104,112 @@ def load_stage_names(path: str) -> List[str]:
     raise ValueError("Unsupported file type for stage names; use .json or .py")
 
 
-def parse_args(argv=None):
-    parser = argparse.ArgumentParser(description="Generate and print a schedule.")
+# Scheduling --------------------------------------------------------------------
+
+Show = Tuple[str, float, float]
+Schedule = Dict[int, List[Show]]
+
+
+def generate_schedule(shows: Sequence[Show]) -> Schedule:
+    """Generate a stage schedule for the given shows.
+
+    Args:
+        shows: A sequence of shows represented as (name, start, end) tuples.
+
+    Returns:
+        Mapping of stage numbers to the list of shows assigned to that stage in
+        chronological order.
+    """
+    events: List[Tuple[float, int, int]] = []
+    for index, (_, start, end) in enumerate(shows):
+        events.append((start, 1, index))  # 1 denotes start
+        events.append((end, 0, index))  # 0 denotes end; ensures end before start when times equal
+
+    events.sort()
+
+    available: List[int] = []
+    next_stage = 1
+    schedule: Schedule = {}
+    show_stage: Dict[int, int] = {}
+
+    for _, event_type, index in events:
+        if event_type == 1:  # start
+            if available:
+                stage = heappop(available)
+            else:
+                stage = next_stage
+                next_stage += 1
+            show_stage[index] = stage
+            schedule.setdefault(stage, []).append(shows[index])
+        else:  # end
+            stage = show_stage[index]
+            heappush(available, stage)
+
+    return schedule
+
+
+def load_shows(path: str) -> List[Show]:
+    """Load shows from a Python module or JSON file."""
+    file_path = Path(path)
+    if file_path.suffix == ".py":
+        spec = importlib.util.spec_from_file_location("shows_module", file_path)
+        if not spec or not spec.loader:
+            raise ImportError(f"Cannot load module from {path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        shows = getattr(module, "shows", None)
+        if shows is None:
+            raise AttributeError(f"Module {path} does not define 'shows'")
+        return list(shows)
+    else:
+        with file_path.open() as f:
+            return [tuple(show) for show in json.load(f)]
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        default="input_shows.py",
+        help="Path to a Python or JSON file providing a 'shows' list.",
+    )
+    parser.add_argument(
+        "--output",
+        help="Optional path to write the resulting schedule as JSON.",
+    )
     parser.add_argument(
         "--stage-names",
-        help="Path to JSON or Python file providing custom STAGE_NAMES",
+        help="Path to JSON or Python file providing custom stage names.",
     )
     return parser.parse_args(argv)
 
 
-def print_schedule(schedule: Iterable[dict], stage_names: List[str] | None = None):
-    if stage_names is None:
-        stage_names = STAGE_NAMES
-    for slot in schedule:
-        stage_num = slot["stage"]
-        if 0 < stage_num <= len(stage_names):
-            name = stage_names[stage_num - 1]
-        else:
-            name = f"Stage {stage_num}"
-        print(f"{slot['time']} - {name} - {slot['band']}")
+def print_schedule(schedule: Schedule, stage_names: Sequence[str] | None = None) -> None:
+    """Pretty-print the schedule to the terminal."""
+    names = list(stage_names or STAGE_NAMES)
+    for stage in sorted(schedule):
+        label = names[stage - 1] if 0 < stage <= len(names) else f"Stage {stage}"
+        print(f"{label}:")
+        for name, start, end in schedule[stage]:
+            print(f"  {name}: {start} - {end}")
 
 
-def main(argv=None):
+def main(argv: Iterable[str] | None = None) -> None:
     args = parse_args(argv)
-    stage_names = STAGE_NAMES
-    if args.stage_names:
-        stage_names = load_stage_names(args.stage_names)
-    example_schedule = [
-        {"time": "10:00", "stage": 1, "band": "Opening Act"},
-        {"time": "11:00", "stage": 2, "band": "Midday Jam"},
-        {"time": "12:00", "stage": 6, "band": "Closing Band"},
-    ]
-    print_schedule(example_schedule, stage_names)
+    shows = load_shows(args.input)
+    names = load_stage_names(args.stage_names) if args.stage_names else STAGE_NAMES
+    schedule = generate_schedule(shows)
+    print_schedule(schedule, names)
+    if args.output:
+        serialisable = {
+            stage: [list(show) for show in shows]
+            for stage, shows in schedule.items()
+        }
+        with open(args.output, "w") as f:
+            json.dump(serialisable, f, indent=2)
 
 
 if __name__ == "__main__":
     main()
+

--- a/tests/test_random_shows.py
+++ b/tests/test_random_shows.py
@@ -1,0 +1,25 @@
+"""Tests for the random show generator."""
+
+import os
+import sys
+import random
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from random_shows import band_names, generate_random_shows
+
+
+def test_generate_random_shows_basic():
+    rng = random.Random(0)
+    shows = generate_random_shows(5, rng=rng, start_hour=0, end_hour=24)
+    assert len(shows) == 5
+    for name, start, end in shows:
+        assert name in band_names
+        assert 0 <= start < end <= 24
+
+
+def test_no_duplicate_names_when_enough():
+    rng = random.Random(1)
+    shows = generate_random_shows(len(band_names), rng=rng)
+    names = [name for name, _, _ in shows]
+    assert len(names) == len(set(names))

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from schedule_generator import print_schedule
+
+
+def test_print_schedule_maps_names(capsys):
+    schedule = [
+        {"time": "10:00", "stage": 1, "band": "Band A"},
+        {"time": "11:00", "stage": 2, "band": "Band B"},
+        {"time": "12:00", "stage": 4, "band": "Band C"},
+    ]
+    names = ["Main Stage", "Second Stage"]
+    print_schedule(schedule, stage_names=names)
+    captured = capsys.readouterr().out
+    assert "10:00 - Main Stage - Band A" in captured
+    assert "11:00 - Second Stage - Band B" in captured
+    assert "12:00 - Stage 4 - Band C" in captured

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,19 +1,65 @@
+"""Unit tests for the festival stage schedule generator."""
+
 import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from schedule_generator import print_schedule
+
+from schedule_generator import generate_schedule, print_schedule
+
+
+def _min_stages(shows):
+    events = []
+    for _, start, end in shows:
+        events.append((start, 1))
+        events.append((end, -1))
+    events.sort()
+    current = max_overlap = 0
+    for _, delta in events:
+        current += delta
+        max_overlap = max(max_overlap, current)
+    return max_overlap
+
+
+def _stage_is_valid(stage_shows):
+    return all(prev[2] <= curr[1] for prev, curr in zip(stage_shows, stage_shows[1:]))
 
 
 def test_print_schedule_maps_names(capsys):
-    schedule = [
-        {"time": "10:00", "stage": 1, "band": "Band A"},
-        {"time": "11:00", "stage": 2, "band": "Band B"},
-        {"time": "12:00", "stage": 4, "band": "Band C"},
-    ]
+    schedule = {
+        1: [("Band A", 10, 11)],
+        2: [("Band B", 11, 12)],
+        4: [("Band C", 12, 13)],
+    }
     names = ["Main Stage", "Second Stage"]
     print_schedule(schedule, stage_names=names)
     captured = capsys.readouterr().out
-    assert "10:00 - Main Stage - Band A" in captured
-    assert "11:00 - Second Stage - Band B" in captured
-    assert "12:00 - Stage 4 - Band C" in captured
+    assert "Main Stage:" in captured
+    assert "  Band A: 10 - 11" in captured
+    assert "Second Stage:" in captured
+    assert "  Band B: 11 - 12" in captured
+    assert "Stage 4:" in captured
+    assert "  Band C: 12 - 13" in captured
+
+
+def test_schedule_minimises_stage_count():
+    shows = [
+        ("show_1", 0, 10),
+        ("show_2", 5, 15),
+        ("show_3", 15, 20),
+    ]
+    schedule = generate_schedule(shows)
+    assert len(schedule) == _min_stages(shows)
+    assert all(_stage_is_valid(s) for s in schedule.values())
+
+
+def test_handles_edge_touching_shows():
+    shows = [
+        ("a", 0, 10),
+        ("b", 10, 20),
+        ("c", 10, 30),
+    ]
+    schedule = generate_schedule(shows)
+    assert len(schedule) == _min_stages(shows)
+    assert all(_stage_is_valid(s) for s in schedule.values())
+


### PR DESCRIPTION
## Summary
- generate default punny stage names and main stage
- add `--stage-names` to load custom lists from json or python
- show stage names in printed schedule with fallback numbering
- document usage and provide tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894f899ee58832b98d21669675e75b6