### PR TITLE
Add customizable stage names to schedule generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,25 @@ python schedule_generator.py --input input_shows.py --output schedule.json
 The `--input` argument accepts a Python or JSON file containing a `shows` list.
 If `--output` is supplied the resulting schedule is written as JSON.
 
+Stages are named with a set of randomly generated puns.  Provide a Python or
+JSON file with custom names to override them:
+
+```bash
+python schedule_generator.py --input input_shows.py --stage-names my_names.py
+```
+
+Where `my_names.py` defines a `STAGE_NAMES` list, e.g.:
+
+```python
+STAGE_NAMES = ["Main Stage", "Chill Zone"]
+```
+
+Alternatively, a JSON file may contain a simple list:
+
+```json
+["Main Stage", "Chill Zone"]
+```
+
 ## Random show generator
 
 `random_shows.py` provides a `generate_random_shows` helper to create random

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -45,3 +45,16 @@ def test_handles_edge_touching_shows():
     schedule = generate_schedule(shows)
     assert len(schedule) == _min_stages(shows)
     assert all(_stage_is_valid(s) for s in schedule.values())
+
+
+def test_print_schedule_uses_stage_names(tmp_path, capsys):
+    import schedule_generator as sg
+
+    stage_file = tmp_path / "names.py"
+    stage_file.write_text("STAGE_NAMES = ['Alpha Arena', 'Beta Base']")
+
+    sg.main(["--input", "input_shows.py", "--stage-names", str(stage_file)])
+
+    out = capsys.readouterr().out.splitlines()
+    assert out[0] == "Alpha Arena:"
+    assert out[3] == "Beta Base:"


### PR DESCRIPTION
## Summary
- add randomised stage names and support for custom names
- allow CLI to load stage name lists from Python or JSON files
- document and test stage name functionality

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894fd303b60832b9193e519103edab0